### PR TITLE
Return the head in PlayerClickHeadEvent

### DIFF
--- a/src/main/java/me/arcaniax/hdb/api/PlayerClickHeadEvent.java
+++ b/src/main/java/me/arcaniax/hdb/api/PlayerClickHeadEvent.java
@@ -114,7 +114,7 @@ public class PlayerClickHeadEvent extends Event {
      * @return null
      */
     public ItemStack getHead() {
-        return null;
+        return this.head;
     }
 
     /**


### PR DESCRIPTION
The head item is in the event but not used or accessible.